### PR TITLE
Tile API Improvement and Doc Examples

### DIFF
--- a/site/docs.md
+++ b/site/docs.md
@@ -184,6 +184,11 @@ and r can be read as "row".
 | q | <code>number</code> | q coordinate of Tile to fetch |
 | r | <code>number</code> | r coordinate of Tile to fetch |
 
+**Example**  
+
+```js
+let originTile = myGrid.getTile(0, 0);
+```
 <a name="HexGrid+getTiles"></a>
 
 ### hexGrid.getTiles() ⇒ <code>Array.Tile</code>
@@ -192,6 +197,14 @@ Returns an array of all tiles in the Grid
 **Kind**: instance method of <code>[HexGrid](#HexGrid)</code>  
 **Overrides:** <code>[getTiles](#Grid+getTiles)</code>  
 **Returns**: <code>Array.Tile</code> - Array of all tiles in this Grid  
+**Example**  
+
+```js
+let tiles = myGrid.getTiles();
+tiles.forEach((tile) => {
+  tile.set("temperature", 75).set("forecast", "sunny");
+});
+```
 <a name="HexGrid+neighborsOf"></a>
 
 ### hexGrid.neighborsOf(q, r) ⇒ <code>Array.Tile</code>
@@ -206,6 +219,14 @@ Returns the Tiles that are adjacent to the Tile at the provided (q, r) coordinat
 | q | <code>number</code> | q coordinate of Tile for which to fetch neighbors |
 | r | <code>number</code> | r coordinate of Tile for which to fetch neighbors |
 
+**Example**  
+
+```js
+let neighborsOfOrigin = myGrid.neighborsOf(0, 0);
+neighborsOfOrigin.forEach((tile) => {
+  tile.set("bordersOrigin", true);
+});
+```
 <a name="HexGrid+distanceBetween"></a>
 
 ### hexGrid.distanceBetween(q1, r1, q2, r2) ⇒ <code>number</code>
@@ -222,6 +243,12 @@ Calculates the distance between two (q, r) coordinates in tiles
 | q2 | <code>number</code> | q coordinate of second tile |
 | r2 | <code>number</code> | r coordinate of second tile |
 
+**Example**  
+
+```js
+let myGrid = new HexGrid(2);
+let distanceFromCenterToEdge = myGrid.distanceBetween(0, 0, 2, -2); // 2
+```
 <a name="Tile"></a>
 
 ## Tile
@@ -233,8 +260,8 @@ pairs representing the state at a discrete location within a [Grid](#Grid).
 * [Tile](#Tile)
     * [new Tile([initialProperties])](#new_Tile_new)
     * [.get(key)](#Tile+get) ⇒ <code>\*</code>
-    * [.set(key, value)](#Tile+set)
-    * [.delete(key)](#Tile+delete)
+    * [.set(key, value)](#Tile+set) ⇒ <code>[Tile](#Tile)</code>
+    * [.delete(key)](#Tile+delete) ⇒ <code>Boolean</code>
 
 <a name="new_Tile_new"></a>
 
@@ -266,30 +293,49 @@ Returns the specified property's value
 | --- | --- | --- |
 | key | <code>key</code> | Name of the property |
 
+**Example**  
+
+```js
+let temperature = hotTile.get("temperature");
+```
 <a name="Tile+set"></a>
 
-### tile.set(key, value)
+### tile.set(key, value) ⇒ <code>[Tile](#Tile)</code>
 Sets the specified property's value, or creates and sets the property if it
 does not yet exist.
 
 **Kind**: instance method of <code>[Tile](#Tile)</code>  
+**Returns**: <code>[Tile](#Tile)</code> - The Tile object  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | key | <code>key</code> | Name of the property to set/create |
 | value | <code>\*</code> | Value of the property |
 
+**Example**  
+
+```js
+hotTile.set("vegetation", ["cactus", "tumbleweed", "wildflowers"]);
+//Chaining
+hotTile.set("one", 1).set("two", 2).set("three", 3);
+```
 <a name="Tile+delete"></a>
 
-### tile.delete(key)
+### tile.delete(key) ⇒ <code>Boolean</code>
 Deletes the specified property, removing it from the Tile completely
 
 **Kind**: instance method of <code>[Tile](#Tile)</code>  
+**Returns**: <code>Boolean</code> - True if an item was actually deleted, false otherwise  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | key | <code>key</code> | Name of the property to delete |
 
+**Example**  
+
+```js
+let didDeleteSomething = hotTile.delete("temperature");
+```
 <a name="Hexagon"></a>
 
 ## Hexagon ⇐ <code>[Shape](#Shape)</code>
@@ -319,6 +365,11 @@ Creates a new Hexagon given the (x, y) position and a radius
 | y | <code>number</code> | y position of the hex center |
 | radius | <code>number</code> | distance from the center to the corners |
 
+**Example**  
+
+```js
+let hex = new Hexagon(0, 0, 100);
+```
 <a name="Hexagon+radius"></a>
 
 ### hexagon.radius : <code>number</code>
@@ -333,6 +384,11 @@ The width of the bounding box of the hexagon
 **Kind**: instance property of <code>[Hexagon](#Hexagon)</code>  
 **Overrides:** <code>[width](#Shape+width)</code>  
 **Returns**: <code>number</code> - The width of the bounding box of the hexagon  
+**Example**  
+
+```js
+let w = hex.width;
+```
 <a name="Hexagon+height"></a>
 
 ### hexagon.height ⇒ <code>number</code>
@@ -341,6 +397,11 @@ The height of the bounding box of the hexagon
 **Kind**: instance property of <code>[Hexagon](#Hexagon)</code>  
 **Overrides:** <code>[height](#Shape+height)</code>  
 **Returns**: <code>number</code> - The height of the bounding box of the hexagon  
+**Example**  
+
+```js
+let h = hex.height;
+```
 <a name="Shape+center"></a>
 
 ### hexagon.center : <code>[Point](#Point)</code>
@@ -384,6 +445,13 @@ Construct a new Point at coordinate (x,y)
 | [x] | <code>number</code> | <code>0</code> | The x coordinate |
 | [y] | <code>number</code> | <code>0</code> | The y coordinate |
 
+**Example**  
+
+```js
+let myPoint = new Point(100, 200);
+myPoint.x = 0;
+myPoint.y = 0;
+```
 <a name="Point+x"></a>
 
 ### point.x : <code>number</code>

--- a/src/modules/grid/HexGrid.js
+++ b/src/modules/grid/HexGrid.js
@@ -52,6 +52,8 @@ class HexGrid extends Grid {
   /**
    * Returns the Tile at axial coordinates (q, r). q can be read as "column",
    * and r can be read as "row".
+   * @example
+   * let originTile = myGrid.getTile(0, 0);
    * @param {number} q - q coordinate of Tile to fetch
    * @param {number} r - r coordinate of Tile to fetch
    * @returns {Tile} The tile at the provided coordinates
@@ -72,6 +74,11 @@ class HexGrid extends Grid {
 
   /**
    * Returns an array of all tiles in the Grid
+   * @example
+   * let tiles = myGrid.getTiles();
+   * tiles.forEach((tile) => {
+   *   tile.set("temperature", 75).set("forecast", "sunny");
+   * });
    * @returns {Array.Tile} Array of all tiles in this Grid
    */
   getTiles() {
@@ -84,6 +91,11 @@ class HexGrid extends Grid {
 
   /**
    * Returns the Tiles that are adjacent to the Tile at the provided (q, r) coordinates.
+   * @example
+   * let neighborsOfOrigin = myGrid.neighborsOf(0, 0);
+   * neighborsOfOrigin.forEach((tile) => {
+   *   tile.set("bordersOrigin", true);
+   * });
    * @param {number} q - q coordinate of Tile for which to fetch neighbors
    * @param {number} r - r coordinate of Tile for which to fetch neighbors
    * @returns {Array.Tile} The array of neighboring Tiles
@@ -102,6 +114,9 @@ class HexGrid extends Grid {
 
   /**
    * Calculates the distance between two (q, r) coordinates in tiles
+   * @example
+   * let myGrid = new HexGrid(2);
+   * let distanceFromCenterToEdge = myGrid.distanceBetween(0, 0, 2, -2); // 2
    * @param {number} q1 - q coordinate of first tile
    * @param {number} r1 - r coordinate of first tile
    * @param {number} q2 - q coordinate of second tile

--- a/src/modules/grid/Tile.js
+++ b/src/modules/grid/Tile.js
@@ -28,19 +28,24 @@ class Tile {
   /**
    * Sets the specified property's value, or creates and sets the property if it
    * does not yet exist.
+   * //Chaining
+   * hotTile.set("one", 1).set("two", 2).set("three", 3);
    * @param {key} key - Name of the property to set/create
    * @param {*} value - Value of the property
+   * @returns {Tile} The Tile object
    */
   set(key, value) {
     this._state.set(key, value);
+    return this;
   }
 
   /**
    * Deletes the specified property, removing it from the Tile completely
    * @param {key} key - Name of the property to delete
+   * @returns {Boolean} True if an item was actually deleted, false otherwise
    */
   delete(key) {
-    this._state.delete(key);
+    return this._state.delete(key);
   }
 }
 

--- a/src/modules/grid/Tile.js
+++ b/src/modules/grid/Tile.js
@@ -18,6 +18,8 @@ class Tile {
 
   /**
    * Returns the specified property's value
+   * @example
+   * let temperature = hotTile.get("temperature");
    * @param {key} key - Name of the property
    * @returns {*} Value of property at `key`
    */
@@ -28,6 +30,8 @@ class Tile {
   /**
    * Sets the specified property's value, or creates and sets the property if it
    * does not yet exist.
+   * @example
+   * hotTile.set("vegetation", ["cactus", "tumbleweed", "wildflowers"]);
    * //Chaining
    * hotTile.set("one", 1).set("two", 2).set("three", 3);
    * @param {key} key - Name of the property to set/create
@@ -41,6 +45,8 @@ class Tile {
 
   /**
    * Deletes the specified property, removing it from the Tile completely
+   * @example
+   * let didDeleteSomething = hotTile.delete("temperature");
    * @param {key} key - Name of the property to delete
    * @returns {Boolean} True if an item was actually deleted, false otherwise
    */

--- a/src/modules/shapes/Hexagon.js
+++ b/src/modules/shapes/Hexagon.js
@@ -9,6 +9,8 @@ import Point from "./Point";
 class Hexagon extends Shape {
   /**
    * Creates a new Hexagon given the (x, y) position and a radius
+   * @example
+   * let hex = new Hexagon(0, 0, 100);
    * @param {number} x - x position of the hex center
    * @param {number} y - y position of the hex center
    * @param {number} radius - distance from the center to the corners
@@ -40,6 +42,8 @@ class Hexagon extends Shape {
 
   /**
    * The width of the bounding box of the hexagon
+   * @example
+   * let w = hex.width;
    * @returns {number} The width of the bounding box of the hexagon
    */
   get width() {
@@ -48,6 +52,8 @@ class Hexagon extends Shape {
 
   /**
    * The height of the bounding box of the hexagon
+   * @example
+   * let h = hex.height;
    * @returns {number} The height of the bounding box of the hexagon
    */
   get height() {

--- a/src/modules/shapes/Point.js
+++ b/src/modules/shapes/Point.js
@@ -5,6 +5,10 @@ class Point {
 
   /**
    * Construct a new Point at coordinate (x,y)
+   * @example
+   * let myPoint = new Point(100, 200);
+   * myPoint.x = 0;
+   * myPoint.y = 0;
    * @param {number} [x=0] - The x coordinate
    * @param {number} [y=0] - The y coordinate
    */

--- a/test/modules/grid/tile.test.js
+++ b/test/modules/grid/tile.test.js
@@ -38,11 +38,24 @@ describe("Tile", () => {
       expect(freshTile.get("habitable")).to.be.true;
     });
 
+    it("set function is chainable", () => {
+      const numberTile = new Tile();
+      numberTile.set("one", 1).set("two", 2).set("three", 3);
+      expect(numberTile.get("one")).to.equal(1);
+      expect(numberTile.get("two")).to.equal(2);
+      expect(numberTile.get("three")).to.equal(3);
+    });
+
     it("can be deleted", () => {
       const coldTile = new Tile({ temperature: -30 });
+
       expect(coldTile.get("temperature")).to.equal(-30);
-      coldTile.delete("temperature");
+      let didDelete = coldTile.delete("temperature");
+      expect(didDelete).to.be.true;
       expect(coldTile.get("temperature")).to.be.undefined;
+
+      didDelete = coldTile.delete("Non-existant key");
+      expect(didDelete).to.be.false;
     });
   });
 });


### PR DESCRIPTION
PR includes:
- Tile#set() now returns the the Tile object, which allows chaining: `tile.set(...).set(...)`
- Tile#delete() now returns a Boolean indicating whether an item was actually deleted
- Example code for most of the API has been written
